### PR TITLE
Fix invoicer for bch

### DIFF
--- a/lib/payment_services/crypto_apis/invoicer.rb
+++ b/lib/payment_services/crypto_apis/invoicer.rb
@@ -44,7 +44,10 @@ class PaymentServices::CryptoApis
         raise response[:meta][:error][:message] if response.dig(:meta, :error, :message)
 
         response[:payload].find do |transaction|
-          received_amount = transaction[:received][invoice.address]
+          # bch has 'bitcoincash:' suffix. If won't affect other currencies
+          address = invoice.address.split(':').last
+
+          received_amount = transaction[:received][address]
           received_amount&.to_d == invoice.amount.to_d && Time.parse(transaction[:datetime]) > invoice.created_at
         end if response[:payload]
       end


### PR DESCRIPTION
bch has `bitcoincash:` suffix at received address.