### PR TITLE
Add condition for bch addresses

### DIFF
--- a/lib/payment_services/crypto_apis/invoicer.rb
+++ b/lib/payment_services/crypto_apis/invoicer.rb
@@ -47,8 +47,7 @@ class PaymentServices::CryptoApis
           # bch has 'bitcoincash:' suffix. If won't affect other currencies
           address = invoice.address.split(':').last
 
-          received_amount = transaction[:received][address]
-          received_amount = transaction[:received][invoice.address] if received_amount.nil?
+          received_amount = transaction[:received][address] || transaction[:received][invoice.address]
           received_amount&.to_d == invoice.amount.to_d && Time.parse(transaction[:datetime]) > invoice.created_at
         end if response[:payload]
       end

--- a/lib/payment_services/crypto_apis/invoicer.rb
+++ b/lib/payment_services/crypto_apis/invoicer.rb
@@ -48,6 +48,7 @@ class PaymentServices::CryptoApis
           address = invoice.address.split(':').last
 
           received_amount = transaction[:received][address]
+          received_amount = transaction[:received][invoice.address] if received_amount.nil?
           received_amount&.to_d == invoice.amount.to_d && Time.parse(transaction[:datetime]) > invoice.created_at
         end if response[:payload]
       end


### PR DESCRIPTION
Дает возможность задать в настройках BCH кошельков адреса в таких форматах:

- `bitcoincash:djgN...`
- `djgN...`