### PR TITLE
CryptoApis: returns legacy bch address format

### DIFF
--- a/lib/payment_services/crypto_apis/client.rb
+++ b/lib/payment_services/crypto_apis/client.rb
@@ -16,7 +16,7 @@ class PaymentServices::CryptoApis
 
     def address_transactions(address)
       safely_parse http_request(
-        url: "#{base_url}/address/#{address}/basic/transactions",
+        url: "#{base_url}/address/#{address}/basic/transactions?legacy=true",
         method: :GET
       )
     end


### PR DESCRIPTION
CryptoApis для BCH по умолчанию возвращает CashAddr формат адресов. Из-за этого при проверке оплаты BCH инвойсов мы не можем найти соответствующую транзакцию:
![](http://joxi.ru/KAgggaouKZW3GA.jpg)

Попросим CryptoApis возвращать нам в legacy формате - мы сможем найти нужную транзакцию:
https://docs.cryptoapis.io/rest-apis/blockchain-as-a-service-apis/bch/index#bch-address-basic-transactions-endpoint