### PR TITLE
Cryptoapis payouts: add default params to queries

### DIFF
--- a/lib/payment_services/crypto_apis/payout_clients/base_client.rb
+++ b/lib/payment_services/crypto_apis/payout_clients/base_client.rb
@@ -5,6 +5,8 @@ require_relative '../clients/base_client'
 class PaymentServices::CryptoApis
   module PayoutClients
     class BaseClient < PaymentServices::CryptoApis::Clients::BaseClient
+      DEFAULT_PARAMS = { replaceable: true }
+
       def make_payout(payout:, wallet:)
         safely_parse http_request(
           url: "#{base_url}/txs/new",
@@ -32,7 +34,7 @@ class PaymentServices::CryptoApis
             }
           },
           wifs: [ wallet.api_secret ]
-        }
+        }.merge(DEFAULT_PARAMS)
       end
     end
   end


### PR DESCRIPTION
> replaceable (boolean) field is only required if you want to allow the transaction to be replaced by a transaction with higher fees (e.g. if you set a low fee and miners are not picking the transaction up for a long period of time).

Это чтобы транзакции которые долго висят немного прибавляли fee и таки были совершены.