### PR TITLE
ETC: проверять транзакцию за -20 сек

### DIFF
--- a/lib/payment_services/crypto_apis/invoicer.rb
+++ b/lib/payment_services/crypto_apis/invoicer.rb
@@ -53,8 +53,7 @@ class PaymentServices::CryptoApis
           received_amount = transaction[:received][invoice.address] unless transaction[:received][invoice.address] == invoice.address 
 
           transaction_created_at = DateTime.strptime(transaction[:timestamp].to_s,'%s').utc
-          invoice_created_at = invoice.created_at.utc
-          invoice_created_at -= ETC_TIME_THRESHOLD if invoice.amount_currency == 'ETC'
+          invoice_created_at = expected_invoice_created_at
 
           next if invoice_created_at >= transaction_created_at
 
@@ -62,6 +61,12 @@ class PaymentServices::CryptoApis
           received_amount&.to_d == invoice.amount.to_d && time_diff.round.minutes < TRANSACTION_TIME_THRESHOLD
         end if response[:payload]
       end
+    end
+
+    def expected_invoice_created_at
+      invoice_created_at = invoice.created_at.utc
+      invoice_created_at -= ETC_TIME_THRESHOLD if invoice.amount_currency == 'ETC'
+      invoice_created_at
     end
 
     def client

--- a/lib/payment_services/crypto_apis/invoicer.rb
+++ b/lib/payment_services/crypto_apis/invoicer.rb
@@ -8,6 +8,7 @@ require_relative 'client'
 class PaymentServices::CryptoApis
   class Invoicer < ::PaymentServices::Base::Invoicer
     TRANSACTION_TIME_THRESHOLD = 30.minutes
+    ETC_TIME_THRESHOLD = 20.seconds
 
     def create_invoice(money)
       Invoice.create!(amount: money, order_public_id: order.public_id, address: order.income_account_emoney)
@@ -53,6 +54,8 @@ class PaymentServices::CryptoApis
 
           transaction_created_at = DateTime.strptime(transaction[:timestamp].to_s,'%s').utc
           invoice_created_at = invoice.created_at.utc
+          invoice_created_at -= ETC_TIME_THRESHOLD if invoice.amount_currency == 'ETC'
+
           next if invoice_created_at >= transaction_created_at
 
           time_diff = (transaction_created_at - invoice_created_at) / 1.minute


### PR DESCRIPTION
https://github.com/alfagen/kassa-admin/issues/890

## Что
нужно сделать так, чтобы в заявках `ETC (Через криптоапис) -> Что-либо` транзакции проверялись за -20 сек от создания заявки

## Чтобы что
Чтобы учесть погрешность времени в блокчейне ETC. Из-за погрешности у некоторых партнеров не создаются заявки.
#### Пример 1
![image](https://user-images.githubusercontent.com/40119577/131503348-f4e306ff-8500-4886-97a8-c0d8429bb062.png)
![image](https://user-images.githubusercontent.com/40119577/131503335-ed240bea-399e-479f-90c6-7bcb895ddbc5.png)
#### Пример 2
![image](https://user-images.githubusercontent.com/40119577/131503394-001b0a0c-018a-417f-8caf-37c4923713c9.png)
![image](https://user-images.githubusercontent.com/40119577/131503407-d46a8665-f133-4071-8f02-729407edd502.png)