### PR TITLE
Binance прием: учитывать token network

### DIFF
--- a/lib/payment_services/binance/client.rb
+++ b/lib/payment_services/binance/client.rb
@@ -9,8 +9,8 @@ class PaymentServices::Binance
       @secret_key = secret_key
     end
 
-    def deposit_history(currency:, network:)
-      query = build_query(params: { coin: currency, network: network })
+    def deposit_history(currency:)
+      query = build_query(params: { coin: currency })
       safely_parse http_request(
         url: "#{API_URL}/sapi/v1/capital/deposit/hisrec?#{query}",
         method: :GET,


### PR DESCRIPTION
https://github.com/alfagen/kassa-admin/pull/920

# Что
Нужно сделать учет параметра network если он указан в платежке для проверки транзакций при приеме платежей через шлюз Binance

## Чтобы что 
Чтобы не создавались заявки созданные в других сетях в рамках указанной валюты. Сейчас создаются.
Заявка:
![image](https://user-images.githubusercontent.com/40119577/133438632-9544b2cd-3b54-4ab3-ae38-d1afd4d7c609.png)
Транзакция:
![image](https://user-images.githubusercontent.com/40119577/133438836-9b766644-7d1a-41d4-ab1c-8cb841895922.png)
Сеть указанная в платежке:
![image](https://user-images.githubusercontent.com/40119577/133439251-c66aa012-5975-484a-a9b0-bb60c4e86a61.png)
