### PR TITLE
Exmo payouts: track transaction id

### DIFF
--- a/lib/payment_services/exmo/client.rb
+++ b/lib/payment_services/exmo/client.rb
@@ -33,8 +33,8 @@ class PaymentServices::Exmo
       )
     end
 
-    def transaction_id(params:)
-      body = URI.encode_www_form(params.merge(nonce: nonce))
+    def transaction_id(task_id:)
+      body = URI.encode_www_form({ task_id: task_id, nonce: nonce })
       safely_parse http_request(
         url: "#{API_URL}/withdraw_get_txid",
         method: :POST,

--- a/lib/payment_services/exmo/client.rb
+++ b/lib/payment_services/exmo/client.rb
@@ -33,6 +33,16 @@ class PaymentServices::Exmo
       )
     end
 
+    def transaction_id(params:)
+      body = URI.encode_www_form(params.merge(nonce: nonce))
+      safely_parse http_request(
+        url: "#{API_URL}/withdraw_get_txid",
+        method: :POST,
+        body: body,
+        headers: build_headers(build_signature(body))
+      )
+    end
+
     private
 
     attr_reader :public_key, :secret_key

--- a/lib/payment_services/exmo/payout.rb
+++ b/lib/payment_services/exmo/payout.rb
@@ -51,14 +51,3 @@ class PaymentServices::Exmo
     end
   end
 end
-
-def scan_number(number)
-  count_of_digits = number.to_s.length
-  if number.positive?
-    "Positive: #{count_of_digits} digits"
-  elsif number.negative?
-    "Negative: #{count_of_digits - 1} digits"
-  else 
-    'Zero'
-  end
-end

--- a/lib/payment_services/exmo/payout.rb
+++ b/lib/payment_services/exmo/payout.rb
@@ -11,6 +11,8 @@ class PaymentServices::Exmo
     monetize :amount_cents, as: :amount
     validates :amount_cents, :destination_account, :state, presence: true
 
+    alias_attribute :txid, :transaction_id
+
     workflow_column :state
     workflow do
       state :pending do
@@ -28,15 +30,18 @@ class PaymentServices::Exmo
       update(task_id: task_id)
     end
 
-    def update_state_by_provider(state)
-      update!(provider_state: state)
-
-      confirm!  if success?
-      fail!     if status_failed?
-    end
-
     def order_fio
       order_payout.order.outcome_fio.presence || order_payout.order.outcome_unk
+    end
+
+    def update_payout_details!(transaction:)
+      update!(
+        provider_state: transaction.provider_state,
+        transaction_id: transaction.id
+      )
+
+      confirm!  if transaction.successful?
+      fail!     if transaction.failed?
     end
 
     private
@@ -44,13 +49,16 @@ class PaymentServices::Exmo
     def order_payout
       @order_payout ||= OrderPayout.find(order_payout_id)
     end
+  end
+end
 
-    def success?
-      provider_state == 'Paid'
-    end
-
-    def status_failed?
-      provider_state == 'Cancelled' || provider_state == 'Error'
-    end
+def scan_number(number)
+  count_of_digits = number.to_s.length
+  if number.positive?
+    "Positive: #{count_of_digits} digits"
+  elsif number.negative?
+    "Negative: #{count_of_digits - 1} digits"
+  else 
+    'Zero'
   end
 end

--- a/lib/payment_services/exmo/payout_adapter.rb
+++ b/lib/payment_services/exmo/payout_adapter.rb
@@ -32,7 +32,7 @@ class PaymentServices::Exmo
       return if raw_transaction.nil?
 
       transaction = Transaction.build_from(raw_transaction: raw_transaction)
-      transaction.id = client.transaction_id({ task_id: payout.task_id })
+      transaction.id = client.transaction_id(task_id: payout.task_id)
       payout.update_payout_details!(transaction: transaction)
       transaction
     end

--- a/lib/payment_services/exmo/payout_adapter.rb
+++ b/lib/payment_services/exmo/payout_adapter.rb
@@ -2,6 +2,7 @@
 
 require_relative 'payout'
 require_relative 'client'
+require_relative 'transaction'
 
 class PaymentServices::Exmo
   class PayoutAdapter < ::PaymentServices::Base::PayoutAdapter
@@ -27,10 +28,11 @@ class PaymentServices::Exmo
       response = client.wallet_operations(currency: wallet.currency.to_s, type: 'withdrawal')
       raise WalletOperationsRequestFailed, "Can't get wallet operations" unless response['items']
 
-      transaction = find_transaction_of(payout: payout, transactions: response['items'])
-      return if transaction.nil?
+      raw_transaction = find_transaction_of(payout: payout, transactions: response['items'])
+      return if raw_transaction.nil?
 
-      payout.update_state_by_provider(transaction['status'])
+      transaction = Transaction.build_from(raw_transaction: raw_transaction)
+      payout.update_payout_details!(transaction: transaction)
       transaction
     end
 

--- a/lib/payment_services/exmo/payout_adapter.rb
+++ b/lib/payment_services/exmo/payout_adapter.rb
@@ -32,7 +32,7 @@ class PaymentServices::Exmo
       return if raw_transaction.nil?
 
       transaction = Transaction.build_from(raw_transaction: raw_transaction)
-      transaction.id = client.transaction_id(task_id: payout.task_id)
+      transaction.id = client.transaction_id(task_id: payout.task_id)['txid']
       payout.update_payout_details!(transaction: transaction)
       transaction
     end

--- a/lib/payment_services/exmo/payout_adapter.rb
+++ b/lib/payment_services/exmo/payout_adapter.rb
@@ -32,6 +32,7 @@ class PaymentServices::Exmo
       return if raw_transaction.nil?
 
       transaction = Transaction.build_from(raw_transaction: raw_transaction)
+      transaction.id = client.transaction_id({ task_id: payout.task_id })
       payout.update_payout_details!(transaction: transaction)
       transaction
     end

--- a/lib/payment_services/exmo/transaction.rb
+++ b/lib/payment_services/exmo/transaction.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class PaymentServices::Exmo
+  class Transaction
+    include Virtus.model
+
+    SUCCESSFULL_PROVIDER_STATE = 'Paid'
+    FAILED_PROVIDER_STATES = %w(Cancelled Error)
+
+    attribute :id, String
+    attribute :provider_state, Integer
+    attribute :source, String
+
+    def self.build_from(raw_transaction:)
+      new(
+        id: raw_transaction['extra']['txid'],
+        provider_state: raw_transaction['status'],
+        source: raw_transaction
+      )
+    end
+
+    def to_s
+      source.to_s
+    end
+
+    def successful?
+      provider_state == SUCCESSFULL_PROVIDER_STATE
+    end
+
+    def failed?
+      FAILED_PROVIDER_STATES.include?(provider_state)
+    end
+  end
+end


### PR DESCRIPTION
### Что?

Необходимо начать отслеживать transaction id для выплат через шлюз Exmo. 

### Чтобы что?

Таким способом избавимся от ошибки:

![photo_2022-05-10 18 21 13](https://user-images.githubusercontent.com/15619524/167664610-3b45db7e-3cfc-4cd5-90c2-54f7f9335279.jpeg)

#### Миграция для бд

https://github.com/alfagen/kassa-admin/pull/1034