### PR TITLE
BlockIO/Exmo payout improvements

### DIFF
--- a/lib/payment_services/block_io/client.rb
+++ b/lib/payment_services/block_io/client.rb
@@ -29,11 +29,13 @@ class PaymentServices::BlockIo
     end
 
     def prepare_transaction(params:)
-      safely_parse http_request(
+      response = safely_parse(http_request(
         url: "#{API_URL}/prepare_transaction?#{params.to_query}",
         method: :GET,
         headers: build_headers
-      )
+      ))
+      raise Exception, response['data'] if response['status'] == 'fail'
+      response
     end
 
     def income_transactions(address)

--- a/lib/payment_services/exmo/payout.rb
+++ b/lib/payment_services/exmo/payout.rb
@@ -13,6 +13,10 @@ class PaymentServices::Exmo
 
     alias_attribute :txid, :transaction_id
 
+    delegate :order, to: :order_payout
+    delegate :outcome_payment_system, to: :order
+    delegate :token_network, to: :outcome_payment_system
+
     workflow_column :state
     workflow do
       state :pending do

--- a/lib/payment_services/exmo/payout_adapter.rb
+++ b/lib/payment_services/exmo/payout_adapter.rb
@@ -6,12 +6,13 @@ require_relative 'transaction'
 
 class PaymentServices::Exmo
   class PayoutAdapter < ::PaymentServices::Base::PayoutAdapter
-    INVOICED_CURRENCIES = %w[XRP XEM]
+    INVOICED_CURRENCIES = %w[xrp xem]
     Error = Class.new StandardError
     PayoutCreateRequestFailed = Class.new Error
     WalletOperationsRequestFailed = Class.new Error
 
     delegate :outcome_transaction_fee_amount, to: :payment_system
+    delegate :neo?, :usdt?, to: :currency, prefix: true
 
     def make_payout!(amount:, payment_card_details:, transaction_id:, destination_account:, order_payout_id:)
       make_payout(
@@ -43,7 +44,7 @@ class PaymentServices::Exmo
       payout = Payout.create!(amount: amount, destination_account: destination_account, order_payout_id: order_payout_id)
       payout_params = {
         amount: amount.to_d + (outcome_transaction_fee_amount || 0),
-        currency: wallet.currency.to_s,
+        currency: currency.upcase,
         address: destination_account
       }
       payout_params[:invoice] = payout.order_fio if invoice_required?
@@ -68,15 +69,11 @@ class PaymentServices::Exmo
     end
 
     def invoice_required?
-      INVOICED_CURRENCIES.include?(wallet.currency.to_s)
+      INVOICED_CURRENCIES.include?(currency)
     end
 
-    def currency_neo?
-      wallet.currency.to_s == 'NEO'
-    end
-
-    def currency_usdt?
-      wallet.currency.to_s == 'USDT'
+    def currency
+      wallet.currency.to_s.downcase.inquiry
     end
   end
 end

--- a/lib/payment_services/exmo/payout_adapter.rb
+++ b/lib/payment_services/exmo/payout_adapter.rb
@@ -48,6 +48,7 @@ class PaymentServices::Exmo
       }
       payout_params[:invoice] = payout.order_fio if invoice_required?
       payout_params[:amount] = payout_params[:amount].to_i if currency_neo?
+      payout_params[:transport] = payout.token_network if currency_usdt?
       response = client.create_payout(params: payout_params)
       raise PayoutCreateRequestFailed, "Can't create payout: #{response['error']}" unless response['result']
 
@@ -72,6 +73,10 @@ class PaymentServices::Exmo
 
     def currency_neo?
       wallet.currency.to_s == 'NEO'
+    end
+
+    def currency_usdt?
+      wallet.currency.to_s == 'USDT'
     end
   end
 end


### PR DESCRIPTION
### Что?

1. Пофиксить баг: https://github.com/alfagen/kassa-admin/issues/1039
2. Добавить возможность выплат USDT через Exmo шлюз. 

### Чтобы что?

1. Офф гем blockio оказался багованый, для некоторых LTC адресов. Будем использовать `prepare_transaction` напрямую.
2. Чтобы был запасной шлюз для выплат USDT