### PR TITLE
BlockIO: Fix amount format

### DIFF
--- a/lib/payment_services/block_io/payout_adapter.rb
+++ b/lib/payment_services/block_io/payout_adapter.rb
@@ -53,7 +53,7 @@ class PaymentServices::BlockIo
       payout = create_payout!(amount: amount, address: destination_account, order_payout_id: order_payout_id)
       response = client.make_payout(
         address: destination_account,
-        amount: amount.to_f,
+        amount: amount.format(decimal_mark: '.', symbol: nil, thousands_separator: ''),
         nonce: transaction_id,
         fee_priority: fee_priority
       )

--- a/lib/payment_services/block_io/payout_adapter.rb
+++ b/lib/payment_services/block_io/payout_adapter.rb
@@ -53,7 +53,7 @@ class PaymentServices::BlockIo
       payout = create_payout!(amount: amount, address: destination_account, order_payout_id: order_payout_id)
       response = client.make_payout(
         address: destination_account,
-        amount: amount.format(decimal_mark: '.', symbol: nil),
+        amount: amount.to_f,
         nonce: transaction_id,
         fee_priority: fee_priority
       )


### PR DESCRIPTION
### Что?

Поправить параметр `amount` в BlockIO шлюзе. Старый вариант, при сумме, например, 1500, форматировал цифру как: `1 500`

### Чтобы что?

Чтобы выплаты для Doge работали, там почти всегда цифры 1000+.