### PR TITLE
BlockIO btc: create an order if transaction is present

### DIFF
--- a/lib/payment_services/block_io/invoicer.rb
+++ b/lib/payment_services/block_io/invoicer.rb
@@ -35,7 +35,7 @@ class PaymentServices::BlockIo
     def transaction_for(invoice)
       transactions = collect_transactions_on(address: invoice.address)
       raw_transaction = transactions.find(&method(:match_transaction?))
-      Transaction.build_from(raw_transaction: raw_transaction) if raw_transaction
+      Transaction.build_from(raw_transaction: raw_transaction.merge('currency' => invoice.amount_currency.downcase)) if raw_transaction
     end
 
     def collect_transactions_on(address:)

--- a/lib/payment_services/block_io/transaction.rb
+++ b/lib/payment_services/block_io/transaction.rb
@@ -23,7 +23,7 @@ class PaymentServices::BlockIo
     end
 
     def successful?
-      confirmations >= CONFIRMATIONS_FOR_COMPLETE
+      currency.btc? || confirmations >= CONFIRMATIONS_FOR_COMPLETE
     end
 
     def created_at
@@ -32,6 +32,12 @@ class PaymentServices::BlockIo
 
     def total_spend
       source['total_amount_sent'].to_f
+    end
+
+    private
+
+    def currency
+      @currency ||= source['currency'].inquiry
     end
   end
 end


### PR DESCRIPTION
https://github.com/alfagen/kassa-admin/issues/1069

### Что?

Необходимо сделать чтобы при приеме BTC через шлюз Blockio оплата подтверждалась сразу, как транзакция попадет в сеть. То есть не ждать 1 или 2 подтверждения, а сразу как заявка будет в блокчейне - создавать новую заявку

### Чтобы что?

Чтобы не ждать 1 или 2 подтверждения, а сразу как заявка будет в блокчейне - создавать новую заявку